### PR TITLE
use env to find php

### DIFF
--- a/bin/puli
+++ b/bin/puli
@@ -1,4 +1,4 @@
-#!/usr/bin/php
+#!/usr/bin/env php
 <?php
 
 /*


### PR DESCRIPTION
Use env to find php.
On a mac with macports php might be installed somewhere else, e.g. /opt/local/bin/php, although /usr/bin/php exists.
