### PR TITLE
Changed "puli build" command to remove obsolete disabled bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+* 1.0.0-beta10 (@release_date@)
+
+ * the `puli build` command now removes obsolete disabled binding UUIDs from
+   the root `puli.json`
+
 * 1.0.0-beta9 (2015-10-06)
 
  * fixed regression in `puli publish` command

--- a/src/Handler/BuildCommandHandler.php
+++ b/src/Handler/BuildCommandHandler.php
@@ -91,6 +91,7 @@ class BuildCommandHandler
         if ('all' === $target || 'discovery' === $target) {
             $this->discoveryManager->clearDiscovery();
             $this->discoveryManager->buildDiscovery();
+            $this->discoveryManager->removeObsoleteDisabledBindingDescriptors();
         }
 
         return 0;

--- a/tests/Handler/BuildCommandHandlerTest.php
+++ b/tests/Handler/BuildCommandHandlerTest.php
@@ -82,6 +82,8 @@ class BuildCommandHandlerTest extends AbstractCommandHandlerTest
             ->method('clearDiscovery');
         $this->discoveryManager->expects($this->at(1))
             ->method('buildDiscovery');
+        $this->discoveryManager->expects($this->at(2))
+            ->method('removeObsoleteDisabledBindingDescriptors');
 
         $statusCode = $this->handler->handle($args);
 
@@ -104,6 +106,8 @@ class BuildCommandHandlerTest extends AbstractCommandHandlerTest
             ->method('clearDiscovery');
         $this->discoveryManager->expects($this->at(1))
             ->method('buildDiscovery');
+        $this->discoveryManager->expects($this->at(2))
+            ->method('removeObsoleteDisabledBindingDescriptors');
 
         $statusCode = $this->handler->handle($args);
 
@@ -126,6 +130,8 @@ class BuildCommandHandlerTest extends AbstractCommandHandlerTest
             ->method('clearDiscovery');
         $this->discoveryManager->expects($this->never())
             ->method('buildDiscovery');
+        $this->discoveryManager->expects($this->never())
+            ->method('removeObsoleteDisabledBindingDescriptors');
 
         $statusCode = $this->handler->handle($args);
 
@@ -148,6 +154,8 @@ class BuildCommandHandlerTest extends AbstractCommandHandlerTest
             ->method('clearDiscovery');
         $this->discoveryManager->expects($this->at(1))
             ->method('buildDiscovery');
+        $this->discoveryManager->expects($this->at(2))
+            ->method('removeObsoleteDisabledBindingDescriptors');
 
         $statusCode = $this->handler->handle($args);
 
@@ -170,6 +178,8 @@ class BuildCommandHandlerTest extends AbstractCommandHandlerTest
             ->method('clearDiscovery');
         $this->discoveryManager->expects($this->never())
             ->method('buildDiscovery');
+        $this->discoveryManager->expects($this->never())
+            ->method('removeObsoleteDisabledBindingDescriptors');
 
         $statusCode = $this->handler->handle($args);
 
@@ -196,6 +206,8 @@ class BuildCommandHandlerTest extends AbstractCommandHandlerTest
             ->method('clearDiscovery');
         $this->discoveryManager->expects($this->never())
             ->method('buildDiscovery');
+        $this->discoveryManager->expects($this->never())
+            ->method('removeObsoleteDisabledBindingDescriptors');
 
         $this->handler->handle($args);
     }


### PR DESCRIPTION
Second part of the fix for puli/issues#36.

Requires https://github.com/puli/manager/pull/16 to build successfully.