### PR TITLE
Show help message when bind/type yields empty list

### DIFF
--- a/src/Handler/BindCommandHandler.php
+++ b/src/Handler/BindCommandHandler.php
@@ -119,7 +119,7 @@ class BindCommandHandler
         }
 
         if ($printAdvice) {
-            $io->writeLine('No resource bindings. Use "puli bind <artifact> <type>" to bind a resource to a type.');
+            $io->writeLine('No bindings found. Use "puli bind <artifact> <type>" to bind an artifact to a type.');
         }
 
         return 0;

--- a/src/Handler/BindCommandHandler.php
+++ b/src/Handler/BindCommandHandler.php
@@ -80,6 +80,7 @@ class BindCommandHandler
         $printBindingState = count($bindingStates) > 1;
         $printPackageName = count($packageNames) > 1;
         $printHeaders = $printBindingState || $printPackageName;
+        $printAdvice = true;
         $indentation = $printBindingState && $printPackageName ? 8
             : ($printBindingState || $printPackageName ? 4 : 0);
 
@@ -95,6 +96,8 @@ class BindCommandHandler
                 if (empty($descriptors)) {
                     continue;
                 }
+
+                $printAdvice = false;
 
                 if (!$bindingStatePrinted) {
                     $this->printBindingStateHeader($io, $bindingState);
@@ -113,6 +116,10 @@ class BindCommandHandler
                     $io->writeLine('');
                 }
             }
+        }
+
+        if ($printAdvice) {
+            $io->writeLine('No resource bindings. Use "puli bind <artifact> <type>" to bind a resource to a type.');
         }
 
         return 0;

--- a/src/Handler/TypeCommandHandler.php
+++ b/src/Handler/TypeCommandHandler.php
@@ -73,7 +73,8 @@ class TypeCommandHandler
         $printStates = count($states) > 1;
         $printPackageName = count($packageNames) > 1;
         $printHeaders = $printStates || $printPackageName;
-        $printAdvice = false;
+        $printTypeAdvice = true;
+        $printBindAdvice = false;
         $indentation = $printStates && $printPackageName ? 8
             : ($printStates || $printPackageName ? 4 : 0);
 
@@ -90,12 +91,14 @@ class TypeCommandHandler
                     continue;
                 }
 
+                $printTypeAdvice = false;
+
                 if (!$statePrinted) {
                     $this->printBindingTypeState($io, $state);
                     $statePrinted = true;
 
                     // Only print the advice if at least one type was printed
-                    $printAdvice = true;
+                    $printBindAdvice = true;
                 }
 
                 if ($printPackageName) {
@@ -114,7 +117,10 @@ class TypeCommandHandler
             }
         }
 
-        if ($printAdvice) {
+        if ($printTypeAdvice) {
+            $io->writeLine('No types defined. Use "puli type --define <name>" to define a type.');
+        }
+        if ($printBindAdvice) {
             $io->writeLine('Use "puli bind <resource> <type>" to bind a resource to a type.');
         }
 

--- a/tests/Handler/BindCommandHandlerTest.php
+++ b/tests/Handler/BindCommandHandlerTest.php
@@ -764,7 +764,7 @@ EOF;
         $statusCode = $this->handler->handleList($args, $this->io);
 
         $expected = <<<EOF
-No resource bindings. Use "puli bind <artifact> <type>" to bind a resource to a type.
+No bindings found. Use "puli bind <artifact> <type>" to bind an artifact to a type.
 
 EOF;
 

--- a/tests/Handler/BindCommandHandlerTest.php
+++ b/tests/Handler/BindCommandHandlerTest.php
@@ -757,6 +757,22 @@ EOF;
         $this->assertEmpty($this->io->fetchErrors());
     }
 
+    public function testListNoBindings()
+    {
+        $args = self::$listCommand->parseArgs(new StringArgs(''));
+
+        $statusCode = $this->handler->handleList($args, $this->io);
+
+        $expected = <<<EOF
+No resource bindings. Use "puli bind <artifact> <type>" to bind a resource to a type.
+
+EOF;
+
+        $this->assertSame(0, $statusCode);
+        $this->assertSame($expected, $this->io->fetchOutput());
+        $this->assertEmpty($this->io->fetchErrors());
+    }
+
     public function testAddResourceBindingWithRelativePath()
     {
         $args = self::$addCommand->parseArgs(new StringArgs('path Puli\Cli\Tests\Fixtures\Foo'));

--- a/tests/Handler/TypeCommandHandlerTest.php
+++ b/tests/Handler/TypeCommandHandlerTest.php
@@ -448,6 +448,28 @@ EOF;
         $this->assertEmpty($this->io->fetchErrors());
     }
 
+    public function testListNoTypes()
+    {
+        $this->discoveryManager = $this->getMock('Puli\Manager\Api\Discovery\DiscoveryManager');
+        $this->discoveryManager->expects($this->any())
+            ->method('findTypeDescriptors')
+            ->willReturn(array());
+        $this->handler = new TypeCommandHandler($this->discoveryManager, $this->packages);
+
+        $args = self::$listCommand->parseArgs(new StringArgs(''));
+
+        $statusCode = $this->handler->handleList($args, $this->io);
+
+        $expected = <<<EOF
+No types defined. Use "puli type --define <name>" to define a type.
+
+EOF;
+
+        $this->assertSame(0, $statusCode);
+        $this->assertSame($expected, $this->io->fetchOutput());
+        $this->assertEmpty($this->io->fetchErrors());
+    }
+
     public function testDefineType()
     {
         $args = self::$defineCommand->parseArgs(new StringArgs('my/type'));


### PR DESCRIPTION
This should fix https://github.com/puli/issues/issues/157

```sh
$ puli type
No types defined. Use "puli type --define <name>" to define a type.
```

```sh
$ puli bind
No resource bindings. Use "puli bind <artifact> <type>" to bind a resource to a type.
```