### PR TITLE
Use composer/ca-bundle for self-update to fix certificate issues

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         "webmozart/expression": "^1.0",
         "webmozart/glob": "^4.0",
         "webmozart/json": "^1.2.2",
-        "padraic/phar-updater": "^1.0.1"
+        "padraic/phar-updater": "^1.0.1",
+        "composer/ca-bundle": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.6",


### PR DESCRIPTION
This PR is a WIP to fix SSL file_get_contents in Puli (https://github.com/puli/issues/issues/163). It uses [composer/ca-bundle](https://github.com/composer/ca-bundle) to fallback to a bundled ca-file if no file is found on the local machine.
